### PR TITLE
feat: add metadata service authentication with token management

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/strettch/sc-metrics-agent/pkg/aggregate"
+	"github.com/strettch/sc-metrics-agent/pkg/clients/metadata"
 	"github.com/strettch/sc-metrics-agent/pkg/clients/tsclient"
 	"github.com/strettch/sc-metrics-agent/pkg/collector"
 	"github.com/strettch/sc-metrics-agent/pkg/config"
@@ -119,6 +120,7 @@ func main() {
 	logger.Info("Starting SC metrics agent",
 		zap.Duration("collection_interval", cfg.CollectionInterval),
 		zap.String("ingestor_endpoint", cfg.IngestorEndpoint),
+		zap.String("metadata_service_endpoint", cfg.MetadataServiceEndpoint),
 		zap.String("vm_id", cfg.VMID),
 		zap.Any("collectors", cfg.Collectors),
 	)
@@ -149,6 +151,7 @@ func main() {
 	}
 	httpClient := tsclient.NewClientWithConfig(clientConfig, logger)
 	metricWriter := tsclient.NewMetricWriter(httpClient, logger)
+	authMgr := metadata.NewAuthManager(cfg, logger)
 
 	// Create processing pipeline
 	pipelineProcessor := pipeline.NewProcessor(
@@ -156,6 +159,7 @@ func main() {
 		metricDecorator,
 		aggregator,
 		metricWriter,
+		authMgr,
 		logger,
 	)
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,6 +8,9 @@ http_timeout: 30s
 # Ingestor endpoint configuration
 ingestor_endpoint: "https://api.cloud.strettch.dev/resource-manager/api/v1/metrics/ingest"
 
+# Metadata service endpoint for authentication
+metadata_service_endpoint: "http://169.254.169.254/metadata/v1/auth-token"
+
 # Agent identification - VM ID will be automatically detected if not specified
 vm_id: ""
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/strettch/sc-metrics-agent
 go 1.24.3
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/klauspost/compress v1.17.9
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
@@ -16,7 +17,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.62.0 // indirect

--- a/pkg/clients/metadata/auth.go
+++ b/pkg/clients/metadata/auth.go
@@ -1,0 +1,96 @@
+package metadata
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+	"github.com/strettch/sc-metrics-agent/pkg/config"
+)
+
+// AuthManager handles periodic token refresh for metadata service authentication.
+type AuthManager struct {
+	client        *Client
+	vmID          string
+	logger        *zap.Logger
+	refreshTicker *time.Ticker
+	stopCh        chan struct{}
+	currentToken  string
+}
+
+// NewAuthManager creates a new auth manager.
+func NewAuthManager(cfg *config.Config, logger *zap.Logger) *AuthManager {
+	client := NewClient(cfg.MetadataServiceEndpoint, cfg.HTTPTimeout, logger)
+	return &AuthManager{
+		client:        client,
+		vmID:          cfg.VMID,
+		logger:        logger,
+		stopCh:        make(chan struct{}),
+		refreshTicker: time.NewTicker(client.tokenLifetime),
+	}
+}
+
+// IsRefreshRunning checks if the background refresh loop is running.
+func (am *AuthManager) IsRefreshRunning() bool {
+	return am.refreshTicker != nil
+}
+
+// fetchAndStoreToken fetches a token and stores it internally.
+func (am *AuthManager) fetchAndStoreToken(ctx context.Context, forceFetch bool) error {
+	if forceFetch {
+		am.logger.Debug("Forcing token refresh")
+		am.client.InvalidateCache()
+	} else {
+		am.logger.Debug("Fetching token (using cache if valid)")
+	}
+	token, err := am.client.GetAuthToken(ctx, am.vmID)
+	if err != nil {
+		return err
+	}
+	am.currentToken = token
+	am.logger.Debug("Token stored successfully")
+	return nil
+}
+
+// EnsureValidToken fetches a valid token and stores it internally.
+func (am *AuthManager) EnsureValidToken(ctx context.Context) error {
+	return am.fetchAndStoreToken(ctx, false)
+}
+
+// StartRefresh starts automatic token refresh.
+func (am *AuthManager) StartRefresh(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case <-am.refreshTicker.C:
+				if err := am.refresh(ctx); err != nil {
+					am.logger.Error("Background token refresh failed", zap.Error(err))
+				}
+			case <-ctx.Done():
+				am.logger.Info("Token refresh stopped due to context cancel")
+				return
+			case <-am.stopCh:
+				am.logger.Info("Token refresh stopped")
+				return
+			}
+		}
+	}()
+}
+
+// refresh invalidates the cache and fetches a new token.
+func (am *AuthManager) refresh(ctx context.Context) error {
+	return am.fetchAndStoreToken(ctx, true)
+}
+
+// GetCurrentToken returns the current authentication token.
+func (am *AuthManager) GetCurrentToken() string {
+	return am.currentToken
+}
+
+// Close stops the refresh loop.
+func (am *AuthManager) Close() {
+	if am.refreshTicker != nil {
+		am.refreshTicker.Stop()
+	}
+	close(am.stopCh)
+}

--- a/pkg/clients/metadata/client.go
+++ b/pkg/clients/metadata/client.go
@@ -1,0 +1,202 @@
+package metadata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const (
+	// Headers
+	HeaderAccept       = "Accept"
+	HeaderXResourceID  = "X-Resource-ID"
+	
+	// Values
+	AcceptJSON = "application/json"
+	
+	// Token cache lifetime
+	TokenCacheLifetime = 30 * time.Minute
+)
+
+// TokenResponse represents the response from the metadata service
+type TokenResponse struct {
+	Token string `json:"token"`
+}
+
+// Client handles communication with the metadata service with token caching
+type Client struct {
+	endpoint      string
+	httpClient    *http.Client
+	logger        *zap.Logger
+	
+	// Token caching
+	tokenMu       sync.RWMutex
+	cachedToken   string
+	tokenExpiry   time.Time
+	tokenLifetime time.Duration
+}
+
+// NewClient creates a new metadata service client with token caching
+func NewClient(endpoint string, timeout time.Duration, logger *zap.Logger) *Client {
+	return &Client{
+		endpoint: endpoint,
+		httpClient: &http.Client{
+			Timeout: timeout,
+			Transport: &http.Transport{
+				MaxIdleConns:        10,
+				MaxIdleConnsPerHost: 10,
+				IdleConnTimeout:     90 * time.Second,
+			},
+		},
+		logger:        logger,
+		tokenLifetime: TokenCacheLifetime,
+	}
+}
+
+// GetAuthToken returns a cached token or fetches a new one if expired
+func (c *Client) GetAuthToken(ctx context.Context, vmID string) (string, error) {
+	// Check if cached token is still valid
+	c.tokenMu.RLock()
+	if c.cachedToken != "" && time.Now().Before(c.tokenExpiry) {
+		token := c.cachedToken
+		c.tokenMu.RUnlock()
+		c.logger.Debug("Using cached auth token", 
+			zap.Duration("remaining_lifetime", time.Until(c.tokenExpiry)))
+		return token, nil
+	}
+	c.tokenMu.RUnlock()
+
+	// Need to fetch a new token
+	c.tokenMu.Lock()
+	defer c.tokenMu.Unlock()
+
+	// Double-check after acquiring write lock
+	if c.cachedToken != "" && time.Now().Before(c.tokenExpiry) {
+		return c.cachedToken, nil
+	}
+
+	// Fetch new token
+	token, err := c.fetchAuthToken(ctx, vmID)
+	if err != nil {
+		return "", err
+	}
+
+	// Cache the token
+	c.cachedToken = token
+	c.tokenExpiry = time.Now().Add(c.tokenLifetime)
+	
+	c.logger.Info("Successfully fetched and cached new auth token",
+		zap.Time("expires_at", c.tokenExpiry),
+		zap.Duration("lifetime", c.tokenLifetime))
+
+	return token, nil
+}
+
+// fetchAuthToken fetches a new authentication token from the metadata service
+func (c *Client) fetchAuthToken(ctx context.Context, vmID string) (string, error) {
+	c.logger.Debug("Fetching new auth token from metadata service", zap.String("endpoint", c.endpoint))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set(HeaderAccept, AcceptJSON)
+	req.Header.Set(HeaderXResourceID, vmID)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		c.logger.Error("Failed to fetch auth token", zap.Error(err))
+		return "", fmt.Errorf("failed to fetch auth token: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			c.logger.Warn("Failed to close response body", zap.Error(closeErr))
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		c.logger.Error("Metadata service returned error",
+			zap.Int("status_code", resp.StatusCode),
+			zap.String("response", string(body)))
+		return "", fmt.Errorf("metadata service returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var tokenResp TokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("failed to unmarshal token response: %w", err)
+	}
+
+	if tokenResp.Token == "" {
+		return "", fmt.Errorf("received empty token from metadata service")
+	}
+
+	c.logger.Debug("Successfully fetched auth token")
+	return tokenResp.Token, nil
+}
+
+// GetAuthTokenWithRetry fetches an auth token with retry logic similar to tsclient
+func (c *Client) GetAuthTokenWithRetry(ctx context.Context, vmID string, maxRetries int, retryDelay time.Duration) (string, error) {
+	var lastErr error
+	
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+		}
+		
+		if attempt > 0 {
+			c.logger.Info("Retrying auth token request",
+				zap.Int("attempt", attempt),
+				zap.Int("max_retries", maxRetries),
+				zap.Duration("wait_time", retryDelay))
+			
+			select {
+			case <-time.After(retryDelay):
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+		}
+		
+		token, err := c.GetAuthToken(ctx, vmID)
+		if err == nil {
+			return token, nil
+		}
+		
+		lastErr = err
+		c.logger.Warn("Auth token request failed", 
+			zap.Error(err), 
+			zap.Int("attempt", attempt))
+	}
+	
+	return "", fmt.Errorf("failed to fetch auth token after %d attempts: %w", maxRetries+1, lastErr)
+}
+
+// InvalidateCache forces the next GetAuthToken call to fetch a new token
+func (c *Client) InvalidateCache() {
+	c.tokenMu.Lock()
+	defer c.tokenMu.Unlock()
+	
+	c.cachedToken = ""
+	c.tokenExpiry = time.Time{}
+	c.logger.Debug("Token cache invalidated")
+}
+
+// Close closes the HTTP client
+func (c *Client) Close() error {
+	c.httpClient.CloseIdleConnections()
+	return nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,9 @@ type Config struct {
 	IngestorEndpoint string        `yaml:"ingestor_endpoint" json:"ingestor_endpoint"`
 	HTTPTimeout      time.Duration `yaml:"http_timeout" json:"http_timeout"`
 
+	// Metadata service settings
+	MetadataServiceEndpoint string `yaml:"metadata_service_endpoint" json:"metadata_service_endpoint"`
+
 	// Agent identification
 	VMID   string            `yaml:"vm_id" json:"vm_id"`
 	Labels map[string]string `yaml:"labels" json:"labels"`
@@ -83,6 +86,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		CollectionInterval: 30 * time.Second,
 		IngestorEndpoint:   "https://api.cloud.strettch.dev/resource-manager/api/v1/metrics/ingest",
+	    MetadataServiceEndpoint: "http://169.254.169.254/metadata/v1/auth-token",
 		HTTPTimeout:        30 * time.Second,
 		VMID:               vmID,
 		Labels:             make(map[string]string),
@@ -224,6 +228,10 @@ func (c *Config) loadFromEnv() {
 
 	if val := os.Getenv("SC_INGESTOR_ENDPOINT"); val != "" {
 		c.IngestorEndpoint = val
+	}
+
+	if val := os.Getenv("SC_METADATA_SERVICE_ENDPOINT"); val != "" {
+		c.MetadataServiceEndpoint = val
 	}
 
 	if val := os.Getenv("SC_HTTP_TIMEOUT"); val != "" {

--- a/test/resource_manager_compatibility_test.go
+++ b/test/resource_manager_compatibility_test.go
@@ -71,7 +71,7 @@ func TestResourceManagerCompatibility_EndToEnd(t *testing.T) {
 
 	// Send metrics
 	ctx := context.Background()
-	response, err := client.SendMetrics(ctx, testMetrics)
+	response, err := client.SendMetrics(ctx, testMetrics, "")
 	require.NoError(t, err)
 	require.NotNil(t, response)
 
@@ -154,7 +154,7 @@ func TestResourceManagerCompatibility_UnsupportedMetrics(t *testing.T) {
 
 	// Send metrics
 	ctx := context.Background()
-	response, err := client.SendMetrics(ctx, testMetrics)
+	response, err := client.SendMetrics(ctx, testMetrics, "")
 	require.NoError(t, err)
 	require.NotNil(t, response)
 
@@ -266,7 +266,7 @@ func TestResourceManagerCompatibility_ValidationErrors(t *testing.T) {
 
 			// Send metrics
 			ctx := context.Background()
-			response, err := client.SendMetrics(ctx, tc.metrics)
+			response, err := client.SendMetrics(ctx, tc.metrics, "")
 			require.NoError(t, err)
 			require.NotNil(t, response)
 
@@ -333,7 +333,7 @@ func TestResourceManagerCompatibility_CompressionAndHeaders(t *testing.T) {
 
 	// Send metrics
 	ctx := context.Background()
-	response, err := client.SendMetrics(ctx, testMetrics)
+	response, err := client.SendMetrics(ctx, testMetrics, "")
 	require.NoError(t, err)
 	require.NotNil(t, response)
 
@@ -416,7 +416,7 @@ func TestResourceManagerCompatibility_BatchProcessing(t *testing.T) {
 
 	// Send batch
 	ctx := context.Background()
-	response, err := client.SendMetrics(ctx, testMetrics)
+	response, err := client.SendMetrics(ctx, testMetrics, "")
 	require.NoError(t, err)
 	require.NotNil(t, response)
 


### PR DESCRIPTION
  - Add metadata service client for fetching auth tokens from VM metadata endpoint
  - Implement AuthManager with automatic token refresh (30-min cache lifetime)
  - Refactor tsclient to accept auth tokens as parameters (stateless design)
  - Update MetricWriter interface to pass auth tokens to all write operations
  - Add metadata_service_endpoint configuration option
  - Initialize auth refresh loop in processor constructor
  - Pass auth tokens from AuthManager through pipeline to HTTP requests

  This enables secure authentication for metrics ingestion using VM-specific
  tokens from the metadata service, with automatic refresh and proper error
  handling throughout the pipeline.