### PR TITLE
refactor: improve filesystem/disk metrics collection with robust filtering

### DIFF
--- a/pkg/collector/metric_validation_test.go
+++ b/pkg/collector/metric_validation_test.go
@@ -46,7 +46,9 @@ var ResourceManagerSupportedMetrics = map[string]bool{
 	"node_network_transmit_packets_total": true,
 
 	// Filesystem Metrics
-	"node_filesystem_size_bytes": true,
+	"node_filesystem_size_bytes":  true,
+	"node_filesystem_free_bytes":  true,
+	"node_filesystem_avail_bytes": true,
 }
 
 // TestCollectorGeneratesOnlySupportedMetrics ensures that our collectors
@@ -274,7 +276,7 @@ func TestResourceManagerMetricWhitelist(t *testing.T) {
 	// If this test fails, it means the resource-manager has changed its supported metrics
 	// and this whitelist needs to be updated
 	
-	expectedCount := 20 // Total number of supported metrics as of latest check
+	expectedCount := 22 // Total number of supported metrics as of latest check
 	actualCount := len(ResourceManagerSupportedMetrics)
 	
 	assert.Equal(t, expectedCount, actualCount, 


### PR DESCRIPTION
  Replace partition number parsing with comprehensive filesystem type filtering
  for more reliable and maintainable disk metrics collection.

  Changes:
  - Add filesystem type filtering to exclude virtual and special filesystems
  - Remove complex partition number parsing logic
  - Simplify collection logic from 40+ lines to ~30 lines
  - Use full device path (/dev/vda2) in device label for consistency
  - Fix edge cases: RAID arrays (md1), LVM volumes, partition 11+, device mapper

  This approach eliminates false positives where valid partitions were
  incorrectly skipped and handles all disk types reliably.