### PR TITLE
feat: add IP address labels to network metrics

### DIFF
--- a/pkg/collector/node_test.go
+++ b/pkg/collector/node_test.go
@@ -302,13 +302,13 @@ func TestMockCollectorBehavior(t *testing.T) {
 
 func TestCollectorRegistry(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	
+
 	// Test that collectors properly register their metrics
 	cfg := config.CollectorConfig{
 		CPU:    true,
 		Memory: true,
 	}
-	
+
 	collector, err := NewSystemCollector(cfg, logger)
 	if err != nil {
 		t.Skip(skipMessageNonLinux)
@@ -318,11 +318,12 @@ func TestCollectorRegistry(t *testing.T) {
 			t.Errorf("Failed to close collector: %v", closeErr)
 		}
 	}()
-	
+
 	// Test that the registry is not nil and contains some metrics
 	// This is implicit through successful collector creation
 	assert.NotNil(t, collector)
-	
+
 	enabled := collector.GetEnabledCollectors()
 	assert.Greater(t, len(enabled), 0, "Should have at least one enabled collector")
 }
+


### PR DESCRIPTION
  Add IP address collection and labeling to network interface metrics
  to enable IP-based classification in the backend (public/private).

  Changes:
  - Add getInterfaceIPAddress() function to retrieve IPv4 addresses from network interfaces with filtering for loopback and link-local addresses (169.254.x.x)
  - Update network metric descriptors to include ip_address label alongside existing device label
  - Modify networkCollector.Collect() to retrieve and attach IP addresses to all network metrics (receive/transmit bytes/packets)
  - Remove isPhysicalInterface() validation to support user-defined interface names and allow backend-side filtering
  - Remove associated test for removed validation function

  This change enables the backend to classify network interfaces as
  public or private based on IP addresses (RFC 1918) rather than
  hardcoded device names, supporting flexible interface naming across
  different environments.

  Technical details:
  - Only IPv4 addresses are collected (filtered via ip.To4())
  - Loopback (127.0.0.1) and link-local (169.254.x.x) addresses excluded
  - Falls back to "none" if no valid IPv4 address found
  - IP address included in metric labels alongside device name